### PR TITLE
fixed open issue in busine3ss profile

### DIFF
--- a/src/modules/business/business.model.js
+++ b/src/modules/business/business.model.js
@@ -18,7 +18,7 @@ const businessHoursSchema = new Schema(
     startMeridiem: { type: String },
     endTime: { type: String },
     endMeridiem: { type: String },
-    enabled: { type: Boolean, default: false },
+    enabled: { type: Boolean, default: true},
   },
   { _id: false }
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Business hours now default to enabled for newly created schedules, preventing them from appearing inactive until manually turned on. This ensures operating hours display and related automations work immediately after setup, reducing onboarding steps. If you previously had to toggle each day on, this change removes that step for new configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->