### PR TITLE
change get all instrument

### DIFF
--- a/src/modules/instrumentFamily/instrumentFamily.controller.js
+++ b/src/modules/instrumentFamily/instrumentFamily.controller.js
@@ -98,7 +98,10 @@ const createInstrument = async (req, res) => {
 
 const getAllInstrument = async (req, res) => {
   try {
-    const result = await instrumentService.getAllInstrument();
+    const name = req.query.name;
+    const id = req.query.id;
+
+    const result = await instrumentService.getAllInstrument({ name, id });
 
     return res.status(200).json({
       success: true,

--- a/src/modules/instrumentFamily/instrumentFamily.service.js
+++ b/src/modules/instrumentFamily/instrumentFamily.service.js
@@ -5,10 +5,42 @@ const createInstrument = async (payload) => {
   return result;
 };
 
-const getAllInstrument = async () => {
-  const result = await InstrumentFamilyModel.find({}).lean().exec();
-  return result;
+const getAllInstrument = async ({ id, name }) => {
+
+  if (id) {
+    // Find the parent document that contains this nested type
+    const instrumentFamily = await InstrumentFamilyModel.findOne({
+      "instrumentTypes._id": id
+    }).lean().exec();
+
+    if (!instrumentFamily) return null;
+
+    // Convert _id to string for comparison
+    const typeObj = instrumentFamily.instrumentTypes.find(
+      t => t._id.toString() === id
+    );
+
+    return typeObj; 
+  }
+  
+  if (name) {
+    const instrumentFamily = await InstrumentFamilyModel.findOne({
+      "instrumentTypes.type": name
+    }).lean().exec();
+
+    if (!instrumentFamily) return null;
+
+    const typeObj = instrumentFamily.instrumentTypes.find(
+      t => t.type === name
+    );
+
+    return typeObj; 
+  }
+
+  const allInstruments = await InstrumentFamilyModel.find({}).lean().exec();
+  return allInstruments;
 };
+
 
 const getInstrumentById = async (id) => {
   return await InstrumentFamilyModel.findById(id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added query support to the instrument family API: filter by id or name to retrieve a specific instrument type; omit filters to get all instrument families.
  - Responses now return the single matching instrument type when a filter is provided, or null if no match is found, improving precision for API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->